### PR TITLE
fix typescript-fetch typos

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
@@ -44,7 +44,7 @@ export interface FetchArgs {
  * @class BaseAPI
  */
 export class BaseAPI {
-    protected configuration: Configuration;
+    protected configuration?: Configuration;
 
     constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected fetch: FetchAPI = portableFetch) {
         if (configuration) {
@@ -61,7 +61,7 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError"
+    name = "RequiredError"
     constructor(public field: string, msg?: string) {
         super(msg);
     }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

It looks like there's a couple typos that cause compilation to fail. I implemented the first two changes suggested in https://github.com/swagger-api/swagger-codegen/issues/11870 as that is what allowed me to build in typescript 4.9.5.

I ran the shell script `./bin/typescript-fetch-petstore.sh` and had test failures. I can't imagine the failures were a result of my code changes however.

I'm targeting typescript but no one is listed for that language on the technical committee.


